### PR TITLE
Fix/slash escaping in branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Be sure to define the `GITLAB_PASSWORD` secret.
 
 ## Changelog
 
+0.2.4 (TBA)
+-----------
+
+Added url-encoding of branch names when retrieving their CI status
+from gitlab.
+
 0.2.3 (2020-05-07)
 ------------------
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ urlencode() (
             *)
 		printf '%%%02X' "'$c" ;;
         esac
-	i=$(( i + 1 ))
+        i=$(( i + 1 ))
     done
 )
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ POLL_TIMEOUT=${POLL_TIMEOUT:-$DEFAULT_POLL_TIMEOUT}
 git checkout "${GITHUB_REF:11}"
 
 branch="$(git symbolic-ref --short HEAD)"
-branch_uri="$(urlencode '${branch}')"
+branch_uri="$(urlencode ${branch})"
 
 sh -c "git config --global credential.username $GITLAB_USERNAME"
 sh -c "git config --global core.askPass /cred-helper.sh"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,17 +3,17 @@
 set -u
 ##################################################################
 urlencode() (
-    # copied from https://gist.github.com/cdown/1163649
-    i=0
-    max_i=${#1}			# length of $1
-    while test $i -lt $max_i; do
-        c="${1:i:1}"
+    i=1
+    max_i=${#1}
+    while test $i -le $max_i; do
+        c="$(expr substr $1 $i 1)"
         case $c in
             [a-zA-Z0-9.~_-])
 		printf "$c" ;;
             *)
 		printf '%%%02X' "'$c" ;;
         esac
+	i=$(( i + 1 ))
     done
 )
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,9 @@ set -u
 ##################################################################
 urlencode() (
     # copied from https://gist.github.com/cdown/1163649
-    length="${#1}"
-    for (( i = 0; i < length; i++ )); do
+    i=0
+    max_i=${#1}			# length of $1
+    while test $i -lt $max_i; do
         c="${1:i:1}"
         case $c in
             [a-zA-Z0-9.~_-])


### PR DESCRIPTION
**Description:**

This PR fixes the issue with no pipeline_id retrieved for branches whose names contain slashes or other kind of special URI symbols by URL-escaping the branch name before using it in URLs.

**Note:**
See [farmlab-client action with this change](https://github.com/stenongithub/farmlab-client/actions/runs/132034526) and [with gitlab-mirror-and-ci-action@0.2.3](https://github.com/stenongithub/farmlab-client/actions/runs/132072365) for comparison.