### PR TITLE
add allow delayed pipelines

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,6 +76,10 @@ elif [ "$ci_status" = "manual" ] # do not return non-triggered manual builds as 
 then 
   curl -d '{"state":"success", "target_url": "'${ci_web_url}'", "context": "gitlab-ci"}' -H "Authorization: token ${GITHUB_TOKEN}"  -H "Accept: application/vnd.github.antiope-preview+json" -X POST --silent "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" 
   exit 0
+elif [ "$ci_status" = "delayed" ] # needed for delayed pipeline in feature env cleanup for webapp 
+then 
+  curl -d '{"state":"success", "target_url": "'${ci_web_url}'", "context": "gitlab-ci"}' -H "Authorization: token ${GITHUB_TOKEN}"  -H "Accept: application/vnd.github.antiope-preview+json" -X POST --silent "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" 
+  exit 0
 elif [ "$ci_status" = "failed" ]
 then 
   curl -d '{"state":"failure", "target_url": "'${ci_web_url}'", "context": "gitlab-ci"}' -H "Authorization: token ${GITHUB_TOKEN}"  -H "Accept: application/vnd.github.antiope-preview+json" -X POST --silent "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" 


### PR DESCRIPTION
Allow Webapp pipelines to go into a `delayed` status regardless of whether feature envs are created which should not be treated as a failure.

Web-app feature environments are created manually and regardless of creation, due to an issue with GL (have fun with this one: https://gitlab.com/gitlab-org/gitlab-foss/-/issues/66602) pipelines go into blocked status with manual jobs using `needs`.
